### PR TITLE
Make more easy to access denops_std module API reference

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -5,4 +5,7 @@ multilingual = false
 src = "src"
 title = "Denops Documentation"
 
+[output.html]
+default-theme = "coal"
+
 [preprocessor.alerts]

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -17,4 +17,5 @@
   - [Properly create a virtual buffer](./tutorial/maze/properly-create-a-virtual-buffer.md)
   - [Properly configured the buffer](./tutorial/maze/properly-configured-the-buffer.md)
   - [Reduce the number of RPC calls](./tutorial/maze/reduce-the-number-of-rpc-calls.md)
+- [API Reference](./api-reference.md)
 - [FAQ](./faq.md)

--- a/src/api-reference.md
+++ b/src/api-reference.md
@@ -1,0 +1,10 @@
+# API Reference
+
+There is a standard module [denops_std] to develop denops plugins. It provides
+various functions to interact with Vim and Neovim and some shorthands to make it
+easier to write plugins.
+
+You can find API references about the module by checking the Deno doc page:
+`https://deno.land/x/denops_std/mod.ts`.
+
+[denops_std]: https://deno.land/x/denops_std/mod.ts


### PR DESCRIPTION
The API for `denops_std` is documented in deno.land, but I still often get lost trying to reach it.

I'm suggesting the following improvements in thi PR:

- Create a page in Denops Documents that introduces the API reference at the heading level, and link to the `denops_std` documentation from the page.
    - <img width="580" alt="menu" src="https://github.com/vim-denops/denops.vim/assets/5582459/ed8a41a1-3c0c-4d4a-b67e-d0de2039e58d">

- (This is not directly related to this issue, but since the standard theme of Denops Documents (`Light`) is almost indistinguishable from the links in the document, we would like to use a more distinguishable style (`Coal`) as the default.
    - before:
        - <img width="600" alt="465b77c09adf0d09dba92c11613e0d84" src="https://github.com/vim-denops/denops.vim/assets/5582459/9a0d854d-151d-457f-be38-adf5f9b36fc5">
    - after:
        - <img width="600" alt="85167509f1efed2bb096d2e734a05ed6" src="https://github.com/vim-denops/denops.vim/assets/5582459/2fd50c53-473b-45f4-88c5-a71738616155">

Referred issue: https://github.com/vim-denops/denops.vim/issues/329.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated the default theme of the documentation to "coal".
	- Added a new "API Reference" section to the documentation, detailing functions and utilities for developing Denops plugins with links to external detailed references.

- **Documentation**
	- Enhanced the documentation structure by introducing a dedicated API reference guide for the `denops_std` module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->